### PR TITLE
Added extensions support. Coffeescript will work!

### DIFF
--- a/tasks/watchify.js
+++ b/tasks/watchify.js
@@ -73,7 +73,8 @@ module.exports = function(grunt) {
     });
     files = _.union(files, self.filesSrc);
 
-    w = index(files, options.callback);
+    var indexOpts = _.extend({entries: files}, _.pick(options, 'extensions'));
+    w = index(indexOpts, options.callback);
     w.on('update', bundle);
     bundle();
 


### PR DESCRIPTION
Added the ability to pass in the extensions option. This is very valuable because it means you can then use grunt-watchify with coffeescript. It should also be really easy to add other options as well by adding to the _.pick list.
